### PR TITLE
Improve error handling

### DIFF
--- a/xled/control.py
+++ b/xled/control.py
@@ -30,7 +30,7 @@ import xled.util
 from xled.auth import BaseUrlChallengeResponseAuthSession
 from xled.compat import xrange
 from xled.exceptions import HighInterfaceError
-from xled.response import ApplicationResponse
+from xled.response import ApplicationResponse, HTTP_FORBIDDEN
 from xled.security import encrypt_wifi_password
 
 log = logging.getLogger(__name__)
@@ -71,6 +71,20 @@ class ControlInterface(object):
             )
             assert self._session
         return self._session
+
+    def session_get(self, url, retriable = True):
+        """
+        Performs a GET on url via a session.
+
+        If the response is 401 error, resets the session and tries again
+        """
+        response = self.session.get(url)
+
+        if response.status_code == HTTP_FORBIDDEN and retriable:
+            self._session = None
+            return self.session_get(url, retriable = False)
+        else:
+            return ApplicationResponse(response)
 
     def firmware_0_update(self, firmware):
         """
@@ -126,9 +140,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "fw/version")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_get(url)
 
     def get_brightness(self):
         """
@@ -138,8 +150,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "led/out/brightness")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_get(url)
         assert sorted(app_response.keys()) == [u"code", u"mode", u"value"]
         return app_response
 
@@ -151,9 +162,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "gestalt")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_get(url)
 
     def get_device_name(self):
         """
@@ -166,8 +175,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "device_name")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_get(url)
         assert sorted(app_response.keys()) == [u"code", u"name"]
         return app_response
 
@@ -179,9 +187,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "network/status")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_get(url)
 
     def get_mode(self):
         """
@@ -195,8 +201,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "led/mode")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_get(url)
         assert sorted(app_response.keys()) == [u"code", u"mode"]
         return app_response
 
@@ -211,8 +216,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "timer")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_get(url)
         assert sorted(app_response.keys()) == [u"time_now", u"time_off", u"time_on"]
         return app_response
 
@@ -224,8 +228,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "led/reset")
-        response = self.session.get(url)
-        return ApplicationResponse(response)
+        return self.session_get(url)
 
     def network_scan(self):
         """
@@ -235,8 +238,7 @@ class ControlInterface(object):
         :rtype: None
         """
         url = urljoin(self.base_url, "network/scan")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_get(url)
         assert list(app_response.keys()) == [u"code"]
 
     def network_scan_results(self):
@@ -247,9 +249,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "network/scan_results")
-        response = self.session.get(url)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_get(url)
 
     def set_brightness(self, brightness=None, enabled=True):
         """

--- a/xled/control.py
+++ b/xled/control.py
@@ -86,6 +86,17 @@ class ControlInterface(object):
         else:
             return ApplicationResponse(response)
 
+    def session_post(self, url, **kwargs):
+        retriable = kwargs.pop('retriable', True)
+
+        response = self.session.post(url, **kwargs)
+
+        if response.status_code == HTTP_FORBIDDEN and retriable:
+            self._session = None
+            return self.session_post(url, retriable = False, **kwargs)
+        else:
+            return ApplicationResponse(response)
+
     def firmware_0_update(self, firmware):
         """
         Uploads first stage of the firmware
@@ -95,9 +106,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "fw/0/update")
-        response = self.session.post(url, data=firmware)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_post(url, data=firmware)
 
     def firmware_1_update(self, firmware):
         """
@@ -108,9 +117,7 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "fw/1/update")
-        response = self.session.post(url, data=firmware)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_post(url, data=firmware)
 
     def firmware_update(self, stage0_sha1sum, stage1_sha1sum):
         """
@@ -128,9 +135,7 @@ class ControlInterface(object):
             }
         }
         url = urljoin(self.base_url, "fw/update")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
-        return app_response
+        return self.session_post(url, json=json_payload)
 
     def firmware_version(self):
         """
@@ -269,8 +274,7 @@ class ControlInterface(object):
         if brightness is not None:
             json_payload["value"] = brightness
         url = urljoin(self.base_url, "led/out/brightness")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
         return app_response
 
@@ -285,8 +289,7 @@ class ControlInterface(object):
         assert len(name) <= 32
         json_payload = {"name": name}
         url = urljoin(self.base_url, "device_name")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
 
     def set_led_movie_config(self, frame_delay, frames_number, leds_number):
@@ -305,7 +308,7 @@ class ControlInterface(object):
             "leds_number": leds_number,
         }
         url = urljoin(self.base_url, "led/movie/config")
-        response = self.session.post(url, json=json_payload)
+        return self.session_post(url, json=json_payload)
         return ApplicationResponse(response)
 
     def set_mode(self, mode):
@@ -319,8 +322,7 @@ class ControlInterface(object):
         assert mode in ("movie", "demo", "off")
         json_payload = {"mode": mode}
         url = urljoin(self.base_url, "led/mode")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
 
     def set_led_movie_full(self, movie):
@@ -332,10 +334,9 @@ class ControlInterface(object):
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
         url = urljoin(self.base_url, "led/movie/full")
-        response = self.session.post(
+        return self.session_post(
             url, headers={"Content-Type": "application/octet-stream"}, data=movie
         )
-        return ApplicationResponse(response)
 
     def set_network_mode_ap(self):
         """
@@ -346,8 +347,7 @@ class ControlInterface(object):
         """
         json_payload = {"mode": 2}
         url = urljoin(self.base_url, "network/status")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
 
     def set_network_mode_station(self, ssid, password):
@@ -366,8 +366,7 @@ class ControlInterface(object):
             "station": {"dhcp": 1, "ssid": ssid, "encpassword": encpassword},
         }
         url = urljoin(self.base_url, "network/status")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
 
     def set_timer(self, time_on, time_off, time_now=None):
@@ -394,10 +393,8 @@ class ControlInterface(object):
 
         json_payload = {"time_on": time_on, "time_off": time_off, "time_now": time_now}
         url = urljoin(self.base_url, "timer")
-        response = self.session.post(url, json=json_payload)
-        app_response = ApplicationResponse(response)
+        app_response = self.session_post(url, json=json_payload)
         assert list(app_response.keys()) == [u"code"]
-
 
 class HighControlInterface(ControlInterface):
     """

--- a/xled/exceptions.py
+++ b/xled/exceptions.py
@@ -24,7 +24,7 @@ class AuthenticationError(XledException):
     """Authentication handshake wasn't successful"""
 
 
-class TokenExpiredError(XledException):
+class TokenExpiredError(ApplicationError):
     """Token is no longer valid"""
 
 

--- a/xled/exceptions.py
+++ b/xled/exceptions.py
@@ -24,9 +24,11 @@ class AuthenticationError(XledException):
     """Authentication handshake wasn't successful"""
 
 
-class TokenExpiredError(ApplicationError):
+class TokenExpiredError(XledException):
     """Token is no longer valid"""
 
+class InvalidTokenError(ApplicationError):
+    """Token was rejected by the device"""
 
 class HighInterfaceError(XledException):
     """High level interface error"""

--- a/xled/exceptions.py
+++ b/xled/exceptions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-class XledException(IOError):
+class XledException(Exception):
     def __init__(self, *args, **kwargs):
         super(XledException, self).__init__(*args, **kwargs)
 

--- a/xled/exceptions.py
+++ b/xled/exceptions.py
@@ -2,8 +2,8 @@
 
 
 class XledException(Exception):
-    def __init__(self, *args, **kwargs):
-        super(XledException, self).__init__(*args, **kwargs)
+    def __init__(self, *args):
+        super(XledException, self).__init__(*args)
 
 
 class ApplicationError(XledException):
@@ -13,7 +13,7 @@ class ApplicationError(XledException):
         """Initializes ApplicationError with `response` object."""
         response = kwargs.pop("response", None)
         self.response = response
-        super(ApplicationError, self).__init__(*args, **kwargs)
+        super(ApplicationError, self).__init__(*args)
 
 
 class ValidationError(XledException):

--- a/xled/response.py
+++ b/xled/response.py
@@ -59,6 +59,9 @@ class ApplicationResponse(Mapping):
                     "No response to create application response data from"
                 )
 
+            if not self.response.ok:
+                raise ApplicationError(self.response.text)
+
             if self.response.raw is None:
                 self._data = {}
             else:

--- a/xled/response.py
+++ b/xled/response.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from xled.exceptions import ApplicationError, TokenExpiredError
+from xled.exceptions import ApplicationError, InvalidTokenError
 from xled.compat import JSONDecodeError, Mapping
 
 HTTP_FORBIDDEN = 401
@@ -61,13 +61,12 @@ class ApplicationResponse(Mapping):
                 )
 
             if self.response.status_code == HTTP_FORBIDDEN:
-                raise TokenExpiredError(self.response.text, response=self.response)
-            elif not self.response.ok:
-                raise ApplicationError(self.response.text, response=self.response)
+                raise InvalidTokenError(self.response.text, response=self.response)
 
             if self.response.raw is None:
                 self._data = {}
             else:
+                self.response.check_for_status()
                 try:
                     json_data = self.response.json()
                 except JSONDecodeError:

--- a/xled/response.py
+++ b/xled/response.py
@@ -2,9 +2,10 @@
 
 from __future__ import absolute_import
 
-from xled.exceptions import ApplicationError
+from xled.exceptions import ApplicationError, TokenExpiredError
 from xled.compat import JSONDecodeError, Mapping
 
+HTTP_FORBIDDEN = 401
 
 class ApplicationResponse(Mapping):
     """The :class:`ApplicationResponse <ApplicationResponse>` object, which
@@ -59,8 +60,10 @@ class ApplicationResponse(Mapping):
                     "No response to create application response data from"
                 )
 
-            if not self.response.ok:
-                raise ApplicationError(self.response.text)
+            if self.response.status_code == HTTP_FORBIDDEN:
+                raise TokenExpiredError(self.response.text, response=self.response)
+            elif not self.response.ok:
+                raise ApplicationError(self.response.text, response=self.response)
 
             if self.response.raw is None:
                 self._data = {}


### PR DESCRIPTION
This PR improves overall stability of the library:

- The base class is changed from `IOError` to `Exception`, as there is nothing wrong with input/output if the twinkly responds with unexpected `code` or `401 Not authorized`
- Removed passing of `**kwargs` to exception constructor, as Python exceptions [do not handle keyword args](https://github.com/python/typeshed/issues/2344#issuecomment-407151110)
- HTTP responses are checked for being successful prior JSON parsing is attempted on body
- 401 responses are translated into `TokenExpiredError`
- `X-Auth-Token` invalidation is handled by retrying the failed request once. 

My Twinkly remembers only the last token issued, so sending a command from mobile app invalidates the session of `xled`. The two last points work around the issue, retrying the failed request if the Twinkly responds with 401 error, and raising the `TokenExpiredError` if the second request fails as well.