### PR TITLE
Refresh invalidated token

### DIFF
--- a/xled/auth.py
+++ b/xled/auth.py
@@ -324,15 +324,22 @@ class BaseUrlChallengeResponseAuthSession(BaseUrlSession):
                                     isn't added to the request.
         :rtype: requests.Response
         """
-        if not withhold_token:
-            headers = self.add_authorization(headers)
+        for attempt in range(2):
+            if not withhold_token:
+                headers = self.add_authorization(headers)
 
-        log.debug("Requesting url %s using method %s.", url, method)
-        log.debug("Supplying headers %s", headers)
-        log.debug("Passing through key word arguments %s.", kwargs)
-        return super(BaseUrlChallengeResponseAuthSession, self).request(
-            method, url, headers=headers, **kwargs
-        )
+            log.debug("Requesting url %s using method %s.", url, method)
+            log.debug("Supplying headers %s", headers)
+            log.debug("Passing through key word arguments %s.", kwargs)
+            response = super(BaseUrlChallengeResponseAuthSession, self).request(
+                method, url, headers=headers, **kwargs
+            )
+            if response.status_code == 401:
+                self.access_token = False
+            else:
+                break
+        return response
+
 
     def add_authorization(self, headers):
         """Returns headers with added authorization

--- a/xled/response.py
+++ b/xled/response.py
@@ -62,6 +62,7 @@ class ApplicationResponse(Mapping):
             if self.response.raw is None:
                 self._data = {}
             else:
+                self.response.raise_for_status()
                 try:
                     json_data = self.response.json()
                 except JSONDecodeError:


### PR DESCRIPTION
This PR replaces #35 

- HTTP responses are checked for being successful prior JSON parsing is attempted on body
- X-Auth-Token invalidation is handled by retrying the failed request once.

My Twinkly remembers only the last token issued, so sending a command from mobile app invalidates the session of xled. The easiest way to reproduce is:

```python
ctrl1 = xled.HighControlInterface(IP)
ctrl2 = xled.HighControlInterface(IP)
ctrl1.is_on() # => False
ctrl2.is_on() # => False
ctrl1.is_on()
```

Without this patch, the last line will raise an exception. This patch will retry authentication first, and an exception will get raised only if the second request fails as well.