### PR TITLE
Change arpreq out for getmac, arpreq fails to compile due to no socke…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "arpreq",
+    "getmac",
     "click-log",
     "Click>=6.0",
     "cryptography",

--- a/xled/discover.py
+++ b/xled/discover.py
@@ -18,7 +18,7 @@ from threading import Thread
 
 import ipaddress
 import zmq
-from arpreq import arpreq
+import getmac
 import tornado.log
 from tornado.ioloop import IOLoop, PeriodicCallback
 from zmq.eventloop.zmqstream import ZMQStream
@@ -460,7 +460,7 @@ class InterfaceAgent(object):
         # if host != ip_address:
         # print("Host {} != ip_address {}".format(host, ip_address))
         log.debug("Getting hardware address of %s.", ip_address)
-        hw_address = arpreq(ip_address)
+        hw_address = getmac.get_mac_address(ip=ip_address)
         if is_py3 and not isinstance(hw_address, bytes):
             hw_address = bytes(hw_address, "utf-8")
         if hw_address is None:


### PR DESCRIPTION
Allow discovery to work on windows.
arpreq requires socket.h which will fail to install/compile via pip.
Changed out for getmac.