### PR TITLE
Generation 2 Failover

### DIFF
--- a/xled/auth.py
+++ b/xled/auth.py
@@ -407,7 +407,7 @@ class ValidatingClientMixin(object):
                 "Generation 2 challenge-response invalid. "
                 "Received challenge-response: %r but %r was expected."
             )
-            log.error(msg, self._challenge_response, expected)
+            log.error(msg, self._challenge_response, self._challenge)
             raise ValidationError()
 
         msg = "challenge-response is correct."

--- a/xled/auth.py
+++ b/xled/auth.py
@@ -486,12 +486,10 @@ class ClientApplication(ValidatingClientMixin):
         :param: app_response response Response from login endpoint.
         :type: application_response :class:`~xled.response.ApplicationResponse`
         """
-        print(vars(response))
         if "authentication_token" in response:
             self._authentication_token = response.get("authentication_token")
 
         if "challenge-response" in response:
-            print(response.get("challenge-response"))
             self._challenge_response = response.get("challenge-response")
 
         if "authentication_token_expires_in" in response:

--- a/xled/auth.py
+++ b/xled/auth.py
@@ -62,10 +62,16 @@ class ChallengeResponseAuth(AuthBase):
 
         if expected != self.challenge_response:
             msg = (
-                "validate_challenge_response(): login sent "
+                "Generation 1 validate_challenge_response(): login sent "
                 "challenge-response: %r. But %r was expected."
             )
-            log.error(msg, self.challenge_response, expected)
+            log.warning(msg, self.challenge_response, expected)
+        elif self._challenge != self._challenge_response:
+            msg = (
+                "Generation 2 validate_challenge_response(): login sent "
+                "challenge-response: %r. But %r was expected."
+            )
+            log.error(msg, self._challenge_response, self._challenge)
             return False
         msg = "validate_challenge_response(): challenge-response is correct."
         log.debug(msg)

--- a/xled/auth.py
+++ b/xled/auth.py
@@ -59,6 +59,7 @@ class ChallengeResponseAuth(AuthBase):
         expected = xled.security.make_challenge_response(
             self.challenge, self.hw_address
         )
+
         if expected != self.challenge_response:
             msg = (
                 "validate_challenge_response(): login sent "
@@ -396,7 +397,14 @@ class ValidatingClientMixin(object):
         expected = xled.security.make_challenge_response(self._challenge, hw_address)
         if expected != self._challenge_response:
             msg = (
-                "challenge-response invalid. "
+                "Generation 1 challenge-response invalid. "
+                "Received challenge-response: %r but %r was expected."
+            )
+            log.warning(msg, self._challenge_response, expected)
+            #raise ValidationError()
+        elif self._challenge != self._challenge_response:
+            msg = (
+                "Generation 2 challenge-response invalid. "
                 "Received challenge-response: %r but %r was expected."
             )
             log.error(msg, self._challenge_response, expected)
@@ -472,10 +480,12 @@ class ClientApplication(ValidatingClientMixin):
         :param: app_response response Response from login endpoint.
         :type: application_response :class:`~xled.response.ApplicationResponse`
         """
+        print(vars(response))
         if "authentication_token" in response:
             self._authentication_token = response.get("authentication_token")
 
         if "challenge-response" in response:
+            print(response.get("challenge-response"))
             self._challenge_response = response.get("challenge-response")
 
         if "authentication_token_expires_in" in response:


### PR DESCRIPTION
Haven't had a full chance to evaluate the protocol and such, but primary investigations and tests show that the Gen 2 devices don't use the security method that V1 devices do. I do not have any V1 devices,  I have a TWS250TP-GUS set.

Debugging the challenge response, it would appear it wants what it gave to us with no modification.
This might be different for commands other than on/off, I haven't yet investigated further.
This pull request adds a fail over catch if a generation 1 response fails, it will check for Gen2 and outputs a warning instead of an error in the case of a Gen1 failure.