### PR TITLE
Musl/api response assertion strictness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,8 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
-      name: black
-      language: system
-      entry: black
-      types: [python]
       language_version: python3.6
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,9 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     tests_require=tests_requirements,
-    extras_require={"tests": tests_requirements,},  # noqa: E231
+    extras_require={
+        "tests": tests_requirements,
+    },  # noqa: E231
     license="MIT license",
     zip_safe=False,
     keywords="xled,twinkly",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27, py35, py36, py37, linters
+envlist = py27, py35, py36, py37, py38, linters
 
 [travis]
 python =
+    3.8: py38
     3.7: py37
     3.6: py36
     3.5: py35

--- a/xled/cli.py
+++ b/xled/cli.py
@@ -35,7 +35,7 @@ def common_preamble(name=None, host_address=None):
         find_id=name, destination_host=host_address
     )
     if name:
-        click.echo("Working on requested device.".format(device_name))
+        click.echo("Working on requested device.")
     else:
         click.echo("Working on device: {}".format(device_name))
     log.debug("HW address = %s", hw_address)

--- a/xled/control.py
+++ b/xled/control.py
@@ -140,7 +140,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "led/out/brightness")
         response = self.session.get(url)
         app_response = ApplicationResponse(response)
-        assert sorted(app_response.keys()) == [u"code", u"mode", u"value"]
+        required_keys = [u"code", u"mode", u"value"]
+        assert all(key in app_response.keys() for key in required_keys)
         return app_response
 
     def get_device_info(self):
@@ -168,7 +169,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "device_name")
         response = self.session.get(url)
         app_response = ApplicationResponse(response)
-        assert sorted(app_response.keys()) == [u"code", u"name"]
+        required_keys = [u"code", u"name"]
+        assert all(key in app_response.keys() for key in required_keys)
         return app_response
 
     def get_network_status(self):
@@ -197,7 +199,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "led/mode")
         response = self.session.get(url)
         app_response = ApplicationResponse(response)
-        assert sorted(app_response.keys()) == [u"code", u"mode"]
+        required_keys = [u"code", u"mode"]
+        assert all(key in app_response.keys() for key in required_keys)
         return app_response
 
     def get_timer(self):
@@ -213,7 +216,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "timer")
         response = self.session.get(url)
         app_response = ApplicationResponse(response)
-        assert sorted(app_response.keys()) == [u"time_now", u"time_off", u"time_on"]
+        required_keys = [u"time_now", u"time_off", u"time_on", u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
         return app_response
 
     def led_reset(self):
@@ -271,7 +275,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "led/out/brightness")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
         return app_response
 
     def set_device_name(self, name):
@@ -287,7 +292,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "device_name")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
 
     def set_led_movie_config(self, frame_delay, frames_number, leds_number):
         """
@@ -321,7 +327,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "led/mode")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
 
     def set_led_movie_full(self, movie):
         """
@@ -348,7 +355,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "network/status")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
 
     def set_network_mode_station(self, ssid, password):
         """
@@ -368,7 +376,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "network/status")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
 
     def set_timer(self, time_on, time_off, time_now=None):
         """
@@ -396,7 +405,8 @@ class ControlInterface(object):
         url = urljoin(self.base_url, "timer")
         response = self.session.post(url, json=json_payload)
         app_response = ApplicationResponse(response)
-        assert list(app_response.keys()) == [u"code"]
+        required_keys = [u"code"]
+        assert all(key in app_response.keys() for key in required_keys)
 
 
 class HighControlInterface(ControlInterface):

--- a/xled/control.py
+++ b/xled/control.py
@@ -422,7 +422,7 @@ class HighControlInterface(ControlInterface):
                 fw_stage_sums[stage] = xled.security.sha1sum(stage1)
             log.debug("Firmware stage %d SHA1SUM: %r", stage, fw_stage_sums[stage])
             if not fw_stage_sums[stage]:
-                msg = "Failed to compute SHA1SUM for firmware stage %d.".format(stage)
+                msg = "Failed to compute SHA1SUM for firmware stage %d." % (stage)
                 raise HighInterfaceError(msg)
                 assert False
 
@@ -454,12 +454,8 @@ class HighControlInterface(ControlInterface):
                 assert False
 
         if fw_stage_sums != uploaded_stage_sums:
-            log.error(
-                "Firmware SHA1SUMs: %r != uploaded SHA1SUMs",
-                fw_stage_sums,
-                uploaded_stage_sums,
-            )
-            msg = "Firmware SHA1SUMs doesn't match to uploaded SHA1SUMs.".format(stage)
+            log.error("Firmware SHA1SUMs: %r != uploaded SHA1SUMs", fw_stage_sums)
+            msg = "Firmware SHA1SUMs doesn't match to uploaded SHA1SUMs."
             raise HighInterfaceError(msg)
             assert False
         else:

--- a/xled/discover.py
+++ b/xled/discover.py
@@ -287,7 +287,7 @@ class Peer(object):
         self.is_alive()
 
     def __repr__(self):
-        return "Peer({0!r})".format(self.hw_address, self.device_id)
+        return "Peer({0!r}) device_id({1!r})".format(self.hw_address, self.device_id)
 
     def is_alive(self):
         """


### PR DESCRIPTION
## Summary of Changes

This pull request makes the assertions for API responses more tolerant of newer firmware changes without sacrificing the ability to fail on breaking changes. It does this by changing the assertion from requiring that the response be the exact set of expected keys to requiring that the request at least have all of the expected keys. This means that newer firmware can return new keys without breaking the library. Firmware changes that remove keys or rename keys will still be detectable.

This pull request also updates inoperative pre-commit hook config, adds python 3.8 to tox testing, and cleans up some string formatting things that were blocking pre-commit hooks and tox tests.

## Test Output

[tox.log](https://github.com/scrool/xled/files/5620943/tox.log)
