### PR TITLE
Replace *nux-only arpreq with getmac

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,17 @@ It turned out that application uses HTTP to control lights. I ended up with
 capturing network traffic and `documented this private API`_. In the end I'm
 able to configure the device pretty easilly.
 
+MacOS Notes
+------------
+
+On MacOS, you might get this error
+
+.. code-block:: python
+
+    socket.gaierror: [Errno 8] nodename nor servname provided, or not known
+
+which is resolved this way: https://stackoverflow.com/a/53382881/43839
+
 Credits
 ---------
 

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "arpreq",
     "click-log",
     "Click>=6.0",
     "cryptography",
+    "getmac",
     "netaddr",
     "pyzmq>=17",
     "requests",

--- a/xled/discover.py
+++ b/xled/discover.py
@@ -18,7 +18,7 @@ from threading import Thread
 
 import ipaddress
 import zmq
-from arpreq import arpreq
+from getmac import get_mac_address
 import tornado.log
 from tornado.ioloop import IOLoop, PeriodicCallback
 from zmq.eventloop.zmqstream import ZMQStream
@@ -460,7 +460,7 @@ class InterfaceAgent(object):
         # if host != ip_address:
         # print("Host {} != ip_address {}".format(host, ip_address))
         log.debug("Getting hardware address of %s.", ip_address)
-        hw_address = arpreq(ip_address)
+        hw_address = get_mac_address(ip=ip_address)
         if is_py3 and not isinstance(hw_address, bytes):
             hw_address = bytes(hw_address, "utf-8")
         if hw_address is None:


### PR DESCRIPTION
* See https://github.com/sebschrader/python-arpreq/issues/9
* Makes xled work on MacOS

Thanks for this very promising library!

I can't test this change with Linux, unfortunately, but it should work perfectly.  Can you patch it in to test perhaps?
