### PR TITLE
Add support for sending realtime UDP frames

### DIFF
--- a/xled/__init__.py
+++ b/xled/__init__.py
@@ -26,6 +26,7 @@ import logging
 from xled.control import ControlInterface, HighControlInterface  # noqa: F401
 from xled.device import Device  # noqa: F401
 from xled.discover import DiscoveryInterface  # noqa: F401
+from xled.realtime import RealtimeChannel  # noqa: F401
 
 from .__version__ import __title__, __description__, __version__  # noqa: F401
 from .__version__ import __author__, __author_email__  # noqa: F401

--- a/xled/control.py
+++ b/xled/control.py
@@ -17,9 +17,12 @@ This module contains interface to control specific device
 
 from __future__ import absolute_import
 
+import base64
 import collections
 import io
 import logging
+import math
+import socket
 import struct
 from operator import xor
 
@@ -36,6 +39,9 @@ log = logging.getLogger(__name__)
 
 #: Time format as defined by C standard
 TIME_FORMAT = "%H:%M:%S"
+
+# UDP port to send realtime frames to
+REALTIME_UDP_PORT_NUMBER = 7777
 
 
 class ControlInterface(object):
@@ -320,11 +326,11 @@ class ControlInterface(object):
         """
         Sets new LED operation mode.
 
-        :param str mode: Mode to set. One of 'movie', 'demo', 'off'.
+        :param str mode: Mode to set. One of 'movie', 'rt', 'demo', 'off'.
         :raises ApplicationError: on application error
         :rtype: None
         """
-        assert mode in ("movie", "demo", "off")
+        assert mode in ("movie", "rt", "demo", "off")
         json_payload = {"mode": mode}
         url = urljoin(self.base_url, "led/mode")
         response = self.session.post(url, json=json_payload)
@@ -409,6 +415,36 @@ class ControlInterface(object):
         app_response = ApplicationResponse(response)
         required_keys = [u"code"]
         assert all(key in app_response.keys() for key in required_keys)
+
+    def send_realtime_frame(self, leds_number, bytes_per_led, data):
+        """
+        Sends a realtime frame. The mode must have been set to 'rt'.
+
+        :param int leds_number: the number of leds in a frame
+        :param int bytes_per_led: the number of bytes per led (3 or 4)
+        :param bytearray data: byte array containing the raw frame data
+        :rtype: None
+        """
+        data_size = leds_number*bytes_per_led
+        assert len(data) == data_size
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            if data_size < 900 and leds_number < 256:
+                # Send single frame
+                packet = bytearray(b'\x01')
+                packet.extend(base64.b64decode(self.session.access_token))
+                packet.extend(bytes([leds_number]))
+                packet.extend(data)
+                sock.sendto(packet, (self.host, REALTIME_UDP_PORT_NUMBER))
+            else:
+                # Send multi frame
+                packet_size = 900//bytes_per_led
+                for i in range(0, math.ceil(data_size/packet_size)):
+                    packet_data = data[:(900//bytes_per_led)]
+                    data = data[(900//bytes_per_led):]
+                    packet = [ b'\x03', base64.b64decode(self.session.access_token),
+                        b'\x00\x00', bytes([i])]
+                    packet.append(packet_data)
+                    sock.sendto(packet, (self.host, REALTIME_UDP_PORT_NUMBER))
 
 
 class HighControlInterface(ControlInterface):

--- a/xled/control.py
+++ b/xled/control.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 #: Time format as defined by C standard
 TIME_FORMAT = "%H:%M:%S"
 
-# UDP port to send realtime frames to
+#: UDP port to send realtime frames to
 REALTIME_UDP_PORT_NUMBER = 7777
 
 

--- a/xled/control.py
+++ b/xled/control.py
@@ -17,12 +17,9 @@ This module contains interface to control specific device
 
 from __future__ import absolute_import
 
-import base64
 import collections
 import io
 import logging
-import math
-import socket
 import struct
 from operator import xor
 
@@ -39,9 +36,6 @@ log = logging.getLogger(__name__)
 
 #: Time format as defined by C standard
 TIME_FORMAT = "%H:%M:%S"
-
-#: UDP port to send realtime frames to
-REALTIME_UDP_PORT_NUMBER = 7777
 
 
 class ControlInterface(object):
@@ -416,38 +410,8 @@ class ControlInterface(object):
         required_keys = [u"code"]
         assert all(key in app_response.keys() for key in required_keys)
 
-    def send_realtime_frame(self, leds_number, bytes_per_led, data):
-        """
-        Sends a realtime frame. The mode must have been set to 'rt'.
 
-        :param int leds_number: the number of leds in a frame
-        :param int bytes_per_led: the number of bytes per led (3 or 4)
-        :param bytearray data: byte array containing the raw frame data
-        :rtype: None
-        """
-        data_size = leds_number*bytes_per_led
-        assert len(data) == data_size
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-            if data_size < 900 and leds_number < 256:
-                # Send single frame
-                packet = bytearray(b'\x01')
-                packet.extend(base64.b64decode(self.session.access_token))
-                packet.extend(bytes([leds_number]))
-                packet.extend(data)
-                sock.sendto(packet, (self.host, REALTIME_UDP_PORT_NUMBER))
-            else:
-                # Send multi frame
-                packet_size = 900//bytes_per_led
-                for i in range(0, math.ceil(data_size/packet_size)):
-                    packet_data = data[:(900//bytes_per_led)]
-                    data = data[(900//bytes_per_led):]
-                    packet = [ b'\x03', base64.b64decode(self.session.access_token),
-                        b'\x00\x00', bytes([i])]
-                    packet.append(packet_data)
-                    sock.sendto(packet, (self.host, REALTIME_UDP_PORT_NUMBER))
-
-
-class HighControlInterface(ControlInterface):
+xclass HighControlInterface(ControlInterface):
     """
     High level interface to control specific device
     """

--- a/xled/realtime.py
+++ b/xled/realtime.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+"""
+xled.realtime
+~~~~~~~~~~~~~
+
+Functions to support the realtime mode of the device.
+"""
+
+from __future__ import absolute_import
+
+import base64
+import math
+import socket
+
+from xled.control import ControlInterface
+
+#: UDP port to send realtime frames to
+REALTIME_UDP_PORT_NUMBER = 7777
+
+
+class RealtimeChannel(object):
+    """
+    Main interface to send realtime frames to device.
+
+    :param control: An activated ControlInterface for the device to control
+    :param int leds_number: the number of leds in a frame
+    :param int bytes_per_led: the number of bytes per led (3 or 4)
+    """
+
+    def __init__(self, control, leds_number, bytes_per_led):
+        self.control = control
+        self.leds_number = leds_number
+        self.bytes_per_led = bytes_per_led
+
+    def start_realtime(self):
+        self.control.set_mode('rt')
+
+    def send_frame(self, data):
+        """
+        Sends a realtime frame. Before calling this, start_realtime() must have
+        been called.
+
+        :param bytearray data: byte array containing the raw frame data
+        :rtype: None
+        """
+        data_size = self.leds_number*self.bytes_per_led
+        assert len(data) == data_size
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            if data_size < 900 and self.leds_number < 256:
+                # Send single frame
+                packet = bytearray(b'\x01')
+                packet.extend(base64.b64decode(self.control.session.access_token))
+                packet.extend(bytes([self.leds_number]))
+                packet.extend(data)
+                sock.sendto(packet, (self.control.host, REALTIME_UDP_PORT_NUMBER))
+            else:
+                # Send multi frame
+                packet_size = 900//self.bytes_per_led
+                for i in range(0, math.ceil(data_size/packet_size)):
+                    packet_data = data[:(900//self.bytes_per_led)]
+                    data = data[(900//self.bytes_per_led):]
+                    packet = [ b'\x03', base64.b64decode(self.control.session.access_token),
+                        b'\x00\x00', bytes([i])]
+                    packet.append(packet_data)
+                    sock.sendto(packet, (self.control.host, REALTIME_UDP_PORT_NUMBER))
+
+


### PR DESCRIPTION
Adds "rt" mode to set_mode() and send_realtime_frame() which takes a byte array with a raw frame and sends it using UDP.

This function is tested for the single packet UDP case, but not for the multipacket case. Testing help is needed!

You can use it like this: (Example from my GRBW 210 led Twinkly):

```
    discovered_device = xled.discover.discover()
    ip = discovered_device.ip_address
    hw = discovered_device.hw_address

    control = xled.ControlInterface(ip, hw)
    control.set_mode('rt')

    for i in range(0, 255):
        with io.BytesIO() as output:
            bytes_str = struct.pack(">BBBB", 0, 0, i, 0)
            for position in xrange(210):
                output.write(bytes_str)
            output.seek(0)
            ba = output.read()
            control.send_realtime_frame(210, 4, ba)
            time.sleep(0.1)
```
