### PR TITLE
Fix errors in `setup.py install` (fix #82)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "click-log",
     "cryptography",
-    "requests",
     "requests-toolbelt",
+    "requests",
 ]
 
 #: Python 2 requirements


### PR DESCRIPTION
I have no idea why this works - it should make no difference, right?

The issue is easily reproducible on a "clean" Python.  I saw it last year when I was developing, and now I see it again in a brand-new OS with a new Python.