### PR TITLE
Configure pytest to collect tests only from tests/

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,5 @@ universal = 1
 [flake8]
 exclude = docs
 
+[tool:pytest]
+testpaths = tests


### PR DESCRIPTION
If one has other directories in the project which are slow to start or
puts files named with a prefix `test_` they won't be processed.

Having configuration in `setup.cfg` should make it possible to use
`pytest` directly or through `tox`