### PR TITLE
Remove references in favor of client implementations section in xled-docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,26 +114,12 @@ second device - Twinkly 210 RGB+W Wall I keep improving this library and CLI
 documentation to be able to operate my devices locally and not rely on
 availability of manufacturer's servers.
 
-References
-----------
+Related projects
+----------------
 
 Unofficial documentation of private protocol and API is `available online`_.
 
-There are other projects that might be more suitable for your needs:
-
-* `Twinkly integration in Home Assistant`_
-* SmartThings:
-
-  * `Twinkly integration in SmartThings by StevenJonSmith`_
-  * `Twinkly integration in SmartThings by Dameon87`_
-
-* `TwinklyTree Binding`_ for openHAB
-* `Twinkly HomeKit Hub for Mongoose OS`_ using `Twinkly library for Mongoose OS`_
-* `TwinklyWPF`_ - .net 5 GUI and API library
-* `ioBroker.twinkly`_ - twinkly adapter for ioBroker to communicate with the Twinkly lights
-* `Twinkly.vb for HomeSeer`_
-* `thingzi-logic-twinkly`_ - Twinkly lights integration for node red
-* Python class to interact with generation I device and IDA Pro loader of firmware binary in `Twinkly Twinkly Little Star by F-Secure LABS`_.
+For other projects that might be more suitable for your needs see `section client implementations in xled-docs`_.
 
 Credits
 ---------
@@ -150,21 +136,11 @@ This package was created with Cookiecutter_ and the
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`documented this private API`: https://xled-docs.readthedocs.io
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
-.. _`Twinkly library for Mongoose OS`: https://github.com/d4rkmen/twinkly
-.. _`Twinkly HomeKit Hub for Mongoose OS`: https://github.com/d4rkmen/twinkly-homekit
-.. _`TwinklyWPF`: https://github.com/MarkAlanJones/TwinklyWPF
-.. _`Twinkly integration in Home Assistant`: https://www.home-assistant.io/integrations/twinkly/
-.. _`ioBroker.twinkly`: https://www.npmjs.com/package/iobroker.twinkly
-.. _`Twinkly.vb for HomeSeer`: https://forums.homeseer.com/forum/developer-support/scripts-plug-ins-development-and-libraries/script-plug-in-library/1348314-twinkly-vb-christmas-tree-lights-with-predefined-and-custom-animations
-.. _`TwinklyTree Binding`: https://github.com/mvanhulsentop/openhab-addons/tree/twinklytree/bundles/org.openhab.binding.twinklytree
-.. _`Twinkly Twinkly Little Star by F-Secure LABS`: https://labs.f-secure.com/blog/twinkly-twinkly-little-star/
-.. _`Twinkly integration in SmartThings by StevenJonSmith`: https://github.com/StevenJonSmith/SmartThings
-.. _`Twinkly integration in SmartThings by Dameon87`: https://github.com/Dameon87/SmartThings
-.. _`thingzi-logic-twinkly`: https://www.npmjs.com/package/thingzi-logic-twinkly
 .. _`pip installed`: https://packaging.python.org/guides/installing-using-linux-tools/
 .. _`create and activate a virtual environment`: https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments
 .. _`xled from PyPI`: https://pypi.org/project/xled/
 .. _`Documentation for the library can be found online`: https://xled.readthedocs.io
+.. _`section client implementations in xled-docs`: https://xled-docs.readthedocs.io/en/latest/readme.html#client-implementations
 
 .. image:: https://badges.gitter.im/xled-community/chat.svg
    :alt: Join the chat at https://gitter.im/xled-community/chat


### PR DESCRIPTION
Now they are in scrool/xled-docs#28