### PR TITLE
Remove 3.6 from supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest]
 
     steps:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -96,9 +96,9 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.6, 3.7, 3.8, 3.9 and
-   3.10. Check https://github.com/scrool/xled/actions and make sure that the
-   tests pass for all supported Python versions.
+3. The pull request should work for Python 2.7, 3.7, 3.8, 3.9 and 3.10.
+   Check https://github.com/scrool/xled/actions and make sure that the tests
+   pass for all supported Python versions.
 
 Tips
 ----

--- a/docs/supported_python_versions.rst
+++ b/docs/supported_python_versions.rst
@@ -15,7 +15,6 @@ Python 3
 
 Following versions of python 3 are supported:
 
-- 3.6
 - 3.7
 - 3.8
 - 3.9

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     extras_require={
         "tests": tests_requirements,
     },  # noqa: E231
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2,!=3.3,!=3.4,!=3.5",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2,!=3.3,!=3.4,!=3.5,!=3.6",
     license="MIT license",
     zip_safe=False,
     keywords="xled,twinkly",
@@ -82,7 +82,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37,38,39,310},linters
+envlist = py{27,37,38,39,310},linters
 
 # Linters
 [testenv:flake8]


### PR DESCRIPTION
Filed ahead of planned EOL on December 23, 2021.