### PR TITLE
HighInterface and CLI: turn on device by trying modes like the app

### DIFF
--- a/xled/cli.py
+++ b/xled/cli.py
@@ -104,8 +104,12 @@ def get_mode(ctx):
 def turn_on(ctx):
     control_interface = common_preamble(ctx.obj.get("name"), ctx.obj.get("hostname"))
     log.debug("Turning on...")
-    control_interface.turn_on()
-    click.echo("Turned on.")
+    try:
+        control_interface.turn_on()
+    except xled.exceptions.HighInterfaceError as hci_err:
+        click.echo("Failed: {}.".format(hci_err), err=True)
+    else:
+        click.echo("Turned on.")
 
 
 @main.command(name="off", help="Turns device off.")

--- a/xled/control.py
+++ b/xled/control.py
@@ -1148,8 +1148,18 @@ class HighControlInterface(ControlInterface):
     def turn_on(self):
         """
         Turns on the device.
+
+        In the order tries to set mode to: playlist or movie. Once the device's
+        response is ok, it stops trying.
+
+        :raises HighInterfaceError: if none of mode sets returned ok response
+        :rtype: :class:`~xled.response.ApplicationResponse`
         """
-        return self.set_mode("movie")
+        for mode in ("playlist", "movie", "effect"):
+            response = self.set_mode(mode)
+            if response.ok:
+                return response
+        raise HighInterfaceError("No device mode returned ok")
 
     def turn_off(self):
         """


### PR DESCRIPTION
If none of set modes succeeded turn_on() of HighInterface raises
exception which is now caught by turn_on() of CLI and correctly reported
back to user.

Fixes: #66