### PR TITLE
Unauthetnicated improvements

### DIFF
--- a/xled/auth.py
+++ b/xled/auth.py
@@ -334,6 +334,12 @@ class BaseUrlChallengeResponseAuthSession(BaseUrlSession):
                 method, url, headers=headers, **kwargs
             )
             if response.status_code == 401:
+                if withhold_token:
+                    log.warning(
+                        "Unexpected HTTP status code 401 to request without added token. Maybe a token is needed for this endpoint?"
+                    )
+                    # Try again, if this was transient issue
+                    continue
                 log.warning(
                     "Unexpected HTTP status code 401 to request with added token."
                 )

--- a/xled/control.py
+++ b/xled/control.py
@@ -186,7 +186,7 @@ class ControlInterface(object):
         :raises ApplicationError: on application error
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
-        response = self.session.get("fw/version")
+        response = self.session.get("fw/version", withhold_token=True)
         app_response = ApplicationResponse(response)
         required_keys = [u"version", u"code"]
         assert all(key in app_response.keys() for key in required_keys)
@@ -212,7 +212,7 @@ class ControlInterface(object):
         :raises ApplicationError: on application error
         :rtype: :class:`~xled.response.ApplicationResponse`
         """
-        response = self.session.get("gestalt")
+        response = self.session.get("gestalt", withhold_token=True)
         app_response = ApplicationResponse(response)
         required_keys = [u"code"]
         assert all(key in app_response.keys() for key in required_keys)


### PR DESCRIPTION
* Withold tokens for known unauthenticated REST API endpoints in control
  This should slightly speed up calls to firmware_version() and
  device_info() if we didn't have authentication token to pass as we don't
  need to get it.

  As a side consequence this should break infinite recursion when we need
  to verify login with devices' hardware address which we might not have
  at the moment the call and we can't call device_info() to get device's
  mac.
* Correct warning log message if a token was withhold from the request