### PR TITLE
Make GitHub action / test workflow working with python 2.7 again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:
@@ -28,4 +28,32 @@ jobs:
           python -m pip install --upgrade tox
       - name: Unit tests
         run: |
-          tox -e py
+          tox --skip-missing-interpreters -e py
+
+  build27:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 2.7
+        uses: MatteoH2O1999/setup-python@v1
+        with:
+          python-version: 2.7
+          allow-build: allow
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip &&
+          python -m pip install --upgrade tox
+
+      - name: Unit tests
+        run: |
+          sudo apt-get update && sudo apt-get install -y locales
+          sudo sed -i -e "s/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" /etc/locale.gen &&
+          sudo dpkg-reconfigure --frontend=noninteractive locales &&
+          sudo update-locale LANG=en_US.UTF-8 &&
+          export LANG=en_US.UTF-8 &&
+          export NO_COLOR=1 &&
+          tox -e py27


### PR DESCRIPTION
Support for [python2.7 has been
removed](https://github.com/actions/setup-python/issues/672) on June 19. Until xled supports 2.7 try to support 2.7 in CI.