### PR TITLE
Remove pyup configuration

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,2 +1,0 @@
-update: insecure
-schedule: "every day"


### PR DESCRIPTION
Primarily because I wasn't able to get this working with python 2.7 since image with 2.7 is no longer available and PyUp wanted to upgrade Sphinx to version which isn't supported on 2.7.